### PR TITLE
enable tracking for messages api

### DIFF
--- a/lib/message.rb
+++ b/lib/message.rb
@@ -19,6 +19,7 @@ module Nylas
     parameter :starred
     parameter :folder
     parameter :labels
+    parameter :tracking
 
     include Nylas::ReadUnreadMethods
 


### PR DESCRIPTION
https://www.nylas.com/docs/platform?curl#message_tracking

Enabled newly added tracking mechanism for Nylas Messages.

Kindly Review.